### PR TITLE
Remove note about alternate password reset for Netflix

### DIFF
--- a/profiles/netflix.com.yaml
+++ b/profiles/netflix.com.yaml
@@ -13,9 +13,6 @@ password:
         form:
           account:
             accepts: [email, phone]
-          notes:
-          - en: Also accepts a combination of first name, last name, and
-                credit card number.
       response:
         email:
           sender: info@mailer.netflix.com


### PR DESCRIPTION
Per #309

Changing the schema to better describe this kind of nuance is being discussed at opws/opws-schemata#14