### PR TITLE
Convert LinkedIn password reset login note to comment

### DIFF
--- a/profiles/linkedin.com.yaml
+++ b/profiles/linkedin.com.yaml
@@ -28,11 +28,8 @@ password:
       submit:
         destination:
           page: stub
-          notes:
-          - en: The stub page includes a "Sign In" link, even though you
-                are signed in after submitting the new password.
         sessions:
-          own: login
+          own: login # even though the stub has a "Sign In" link
           notes:
           - en: The form to submit the password includes a checkbox
                 to control whether other sessions should be logged


### PR DESCRIPTION
Per #309

This note illustrating contradictory behavior doesn't strictly qualify as "password errata" (as added with opws/opws-schemata#5), but would appear contradictory when reviewing the profile, which is why it's kept around as a comment.