### PR TITLE
Fix profiles/ticketmaster.com.yaml

### DIFF
--- a/profiles/ticketmaster.com.yaml
+++ b/profiles/ticketmaster.com.yaml
@@ -6,7 +6,7 @@ password:
       max: 32
   contents:
     required:
-      classes:
+    - classes:
       - alpha
       - digit
     blacklist:


### PR DESCRIPTION
Turns out CI was busted and not reporting invalid profiles (fixed by opws/opws-validate#5).